### PR TITLE
compatibility >= gitbucket-4.19, simplified build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,41 +1,16 @@
-val Organization = "com.github.lefou"
-// Don't forget to also update src/main/scala/Plugin.scala
-val Version = "1.0.2"
+name := "gitbucket-asciidoctor-plugin"
+organization := "com.github.lefou"
+version := "1.1.0"
+scalaVersion := "2.12.4"
+gitbucketVersion := "4.19.0"
 
-val CompatMode = System.getenv("COMPAT_MODE") == "1"
+resolvers ++= Seq(
+  Resolver.jcenterRepo,
+  Resolver.mavenLocal
+)
 
-val ScalaVersion = if(CompatMode) "2.11.8" else "2.12.1"
-
-val GitBucketVersion = if(CompatMode) "4.0" else "4.10"
-val GitBucketAssembly =
-  if(CompatMode) "gitbucket" % "gitbucket-assembly" % s"${GitBucketVersion}.0"
-  else "io.github.gitbucket" %% "gitbucket" % s"${GitBucketVersion}.0"
-val JavaOptions =
-  if(CompatMode) Seq("-target", "7", "-source", "7")
-  else Seq("-target", "8", "-source", "8")
-
-val Name = s"gitbucket-${GitBucketVersion}-asciidoctor-plugin"
-
-
-lazy val root = (project in file(".")).
-  settings(
-    sourcesInBase := false,
-    organization := Organization,
-    name := Name,
-    version := Version,
-    scalaVersion := ScalaVersion,
-    scalacOptions := Seq("-deprecation", "-language:postfixOps"),
-    resolvers ++= Seq(
-      "amateras-repo" at "http://amateras.sourceforge.jp/mvn/"
-    ),
-    libraryDependencies ++= Seq(
-      GitBucketAssembly % "provided",
-      "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided",
-      "org.asciidoctor" % "asciidoctorj" % "1.5.4",
-      "net.sourceforge.htmlcleaner" % "htmlcleaner" % "2.16"
-    ),
-    javacOptions in compile ++= JavaOptions,
-
-    assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
-
-  )
+libraryDependencies ++= Seq(
+  "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided",
+  "org.asciidoctor" % "asciidoctorj" % "1.5.4",
+  "net.sourceforge.htmlcleaner" % "htmlcleaner" % "2.16"
+)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version=1.1.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.0")
+addSbtPlugin("io.github.gitbucket" % "sbt-gitbucket-plugin" % "1.2.0")

--- a/src/main/scala/Plugin.scala
+++ b/src/main/scala/Plugin.scala
@@ -17,7 +17,8 @@ class Plugin extends gitbucket.core.plugin.Plugin {
   override val description: String = "Provides AsciiDoc rendering for GitBucket."
   override val versions: List[Version] = List(
     new Version("1.0.1"),
-    new Version("1.0.2")
+    new Version("1.0.2"),
+    new Version("1.1.0")
   )
 
   private[this] var renderer: Option[AsciidoctorRenderer] = None


### PR DESCRIPTION
As I needed to give your plugin a trial on my own 4.22 installation, I updated it and adapted it to match standard builds from official plugins (like gitbucket-notifications-plugin).